### PR TITLE
✨ Implementing Yaml Serializer to an Abstract Factory using SOLID

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,12 +12,18 @@ def proceed():
     xml: str = song.serialize(FormatType.XML)
     print(xml)
 
+    yaml: str = song.serialize(FormatType.YAML)
+    print(yaml)
+
 
 """
 Output:
 
-{"id": "20240411-154543-41473bee-22e7-44fd-992a-f08c2d2d8454", "title": "You are more", "artist": "Tenth Avenue North"}
-<song_id id="20240411-154543-41473bee-22e7-44fd-992a-f08c2d2d8454"><title>You are more</title><artist>Tenth Avenue North</artist></song_id>
+{"id": "20240411-160311-f4524550-1b65-4b4e-8c23-bc6d081b5af7", "title": "You are more", "artist": "Tenth Avenue North"}
+<song_id id="20240411-160311-f4524550-1b65-4b4e-8c23-bc6d081b5af7"><title>You are more</title><artist>Tenth Avenue North</artist></song_id>
+artist: Tenth Avenue North
+id: 20240411-160311-f4524550-1b65-4b4e-8c23-bc6d081b5af7
+title: You are more
 """
 
 if __name__ == "__main__":

--- a/serializer/constants/registers.py
+++ b/serializer/constants/registers.py
@@ -2,14 +2,17 @@ from enum import Enum
 from serializer.serializers.Serializer import Serializer
 from serializer.serializers.impl.JsonSerializer import JsonSerializer
 from serializer.serializers.impl.XmlSerializer import XmlSerializer
+from serializer.serializers.impl.YamlSerializer import YamlSerializer
 
 
 class FormatType(Enum):
     JSON: str = 'JSON'
     XML: str = 'XML'
+    YAML: str = "YAML"
 
 
 serializer_registers: dict[FormatType, type[Serializer]] = {
     FormatType.JSON: JsonSerializer,
     FormatType.XML: XmlSerializer,
+    FormatType.YAML: YamlSerializer,
 }

--- a/serializer/serializers/impl/YamlSerializer.py
+++ b/serializer/serializers/impl/YamlSerializer.py
@@ -1,0 +1,8 @@
+import yaml
+
+from serializer.serializers.impl.JsonSerializer import JsonSerializer
+
+
+class YamlSerializer(JsonSerializer):
+    def to_str(self):
+        return yaml.dump(self._current_object)


### PR DESCRIPTION
Adding a new format (YAML) to the factory without changing anything on factories files.

STEPS

1. Create your format implementation file. #YamlSerializer.py on this example.
2. Register your new format implementation under registers.py file.
3. Done, your classes that inherited Serializable already can serialize to Yaml format now.